### PR TITLE
Fix NPE during DBLongArray creation when null is passed

### DIFF
--- a/src/main/java/org/xelasov/ejdbc/types/DBLongArray.java
+++ b/src/main/java/org/xelasov/ejdbc/types/DBLongArray.java
@@ -35,8 +35,10 @@ public class DBLongArray extends Parameter<Long[]> {
   @Override
   public void apply(CallableStatementWrapper stmt, int pos) throws SQLException {
     if (isInput()) {
-      final Array arr = stmt.getCallableStatement().getConnection().createArrayOf("int8", val);
-      stmt.setArray(pos, arr);
+      Array arr = null;
+      if(val != null)
+        arr = stmt.getCallableStatement().getConnection().createArrayOf("int8", val);
+      stmt.setArrayOrNull(pos, arr);
     }
     if (isOutput())
       stmt.registerOutParameter(pos, Types.ARRAY);


### PR DESCRIPTION
For stored procs that have optional params, DBLongArray throws a NullPointerException when null is passed - 

[ Exception in thread "main" java.lang.NullPointerException
    at java.lang.reflect.Array.getLength(Native Method)
    at org.postgresql.jdbc4.AbstractJdbc4Connection.appendArray(AbstractJdbc4Connection.java:108)
    at org.postgresql.jdbc4.AbstractJdbc4Connection.createArrayOf(AbstractJdbc4Connection.java:97)
    at org.postgresql.jdbc4.Jdbc4Connection.createArrayOf(Jdbc4Connection.java:21)
    at org.xelasov.ejdbc.types.DBLongArray.apply(DBLongArray.java:40) ..]

The fix calls createArrayOf only when a non-null value is passed, sets null otherwise. 
